### PR TITLE
Relax peer dependencies to react@16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#25](https://github.com/compulim/use-memo-map-pull/25) and [#27](https://github.com/compulim/use-memo-map-pull/27)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#29](https://github.com/compulim/use-memo-map/pull/29)
+- Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#25](https://github.com/compulim/use-memo-map-pull/25), [#27](https://github.com/compulim/use-memo-map-pull/27), and [#29](https://github.com/compulim/use-memo-map/pull/29)
    - Production dependencies
       - [`@babel/runtime-corejs3@7.24.1`](https://npmjs.com/package/@babel/runtime-corejs3)
-      - [`use-ref-from@0.0.3`](https://npmjs.com/package/use-ref-from)
+      - [`use-ref-from@0.1.0`](https://npmjs.com/package/use-ref-from)
    - Development dependencies
       - [`@babel/cli@7.24.1`](https://npmjs.com/package/@babel/cli)
       - [`@babel/core@7.24.3`](https://npmjs.com/package/@babel/core)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "use-memo-map-root",
-  "version": "0.0.5-0",
+  "version": "0.1.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "use-memo-map-root",
-      "version": "0.0.5-0",
+      "version": "0.1.0-0",
       "license": "MIT",
       "workspaces": [
         "packages/use-memo-map",
@@ -9338,15 +9338,15 @@
       "link": true
     },
     "node_modules/use-ref-from": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.0.3.tgz",
-      "integrity": "sha512-+HY0IesN9DMuD0gnvGP3U2NTWYE+AwdCQnuuihpi5tNeFxQGPEcWH7b8ayvwElYJm6RcHsuo7lnVd+do02ghnQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/use-ref-from/-/use-ref-from-0.1.0.tgz",
+      "integrity": "sha512-PRjmfhUGUKghhOjKV1dBU66M7CASdb4NkMsaaWLdJA81yOZFlVL7Pi3O9aD+68pRh0VrRQjZfS6Ux3vPy1VhRg==",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.23.1",
-        "use-ref-from": "^0.0.3"
+        "@babel/runtime-corejs3": "^7.24.1",
+        "use-ref-from": "^0.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -9685,7 +9685,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.24.1",
-        "use-ref-from": "^0.0.3"
+        "use-ref-from": "^0.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-memo-map-root",
-  "version": "0.0.5-0",
+  "version": "0.1.0-0",
   "description": "",
   "private": true,
   "author": "William Wong (https://github.com/compulim)",

--- a/packages/integration-test/importDefault.test.mjs
+++ b/packages/integration-test/importDefault.test.mjs
@@ -1,7 +1,12 @@
 /** @jest-environment jsdom */
 
-import { renderHook } from '@testing-library/react';
 import { useMemoMap } from 'use-memo-map';
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', () => {
   // GIVEN: A "multiply by 10" mapper.

--- a/packages/integration-test/importNamed.test.mjs
+++ b/packages/integration-test/importNamed.test.mjs
@@ -1,7 +1,12 @@
 /** @jest-environment jsdom */
 
-import { renderHook } from '@testing-library/react';
 import useMemoMap from 'use-memo-map/useMemoMap';
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', () => {
   // GIVEN: A "multiply by 10" mapper.

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -14,10 +14,29 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-memo-map": "^0.0.0-0"
   },
-  "pinDependencies": {},
   "devDependencies": {
     "@babel/core": "^7.24.3",
     "@babel/preset-env": "^7.24.3",

--- a/packages/integration-test/requireDefault.test.cjs
+++ b/packages/integration-test/requireDefault.test.cjs
@@ -1,7 +1,12 @@
 /** @jest-environment jsdom */
 
-const { renderHook } = require('@testing-library/react');
 const { useMemoMap } = require('use-memo-map');
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', () => {
   // GIVEN: A "multiply by 10" mapper.

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -1,7 +1,12 @@
 /** @jest-environment jsdom */
 
-const { renderHook } = require('@testing-library/react');
 const { default: useMemoMap } = require('use-memo-map/useMemoMap');
+
+const renderHook =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', () => {
   // GIVEN: A "multiply by 10" mapper.

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -16,6 +16,36 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@types/react": "^16",
+      "@types/react-dom": "^16"
+    },
+    "dependencies": {
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@types/react": "^17",
+      "@types/react-dom": "^17"
+    },
+    "dependencies": {
+      "react": "17.0.0",
+      "react-dom": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "@types/react-dom": "^18"
+    },
+    "dependencies": {
+      "react": "18.0.0",
+      "react-dom": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "use-memo-map": "^0.0.0-0"
   },

--- a/packages/use-memo-map/package.json
+++ b/packages/use-memo-map/package.json
@@ -67,7 +67,31 @@
     "url": "https://github.com/compulim/use-memo-map/issues"
   },
   "homepage": "https://github.com/compulim/use-memo-map#readme",
-  "pinDependencies": {},
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "@types/react": "^16",
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@testing-library/react-hooks": "latest",
+      "@types/react": "^17",
+      "react": "17.0.0",
+      "react-dom": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "react": "18.0.0",
+      "react-dom": "18.0.0"
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
     "@babel/core": "^7.24.3",
@@ -88,10 +112,10 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.24.1",
-    "use-ref-from": "^0.0.3"
+    "use-ref-from": "^0.1.0"
   }
 }

--- a/packages/use-memo-map/src/useMemoMap.spec.ts
+++ b/packages/use-memo-map/src/useMemoMap.spec.ts
@@ -1,7 +1,15 @@
 /** @jest-environment jsdom */
 
-import { renderHook } from '@testing-library/react';
 import useMemoMap from './useMemoMap';
+
+const renderHook: <T, P>(
+  render: (props: P) => T,
+  options?: { initialProps: P }
+) => { rerender: (props?: P) => void; result: { current: T } } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react').renderHook ||
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@testing-library/react-hooks').renderHook;
 
 test('simple scenario', () => {
   // GIVEN: A mapper of x *= 10.


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#29](https://github.com/compulim/use-memo-map/pull/29)
- Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#25](https://github.com/compulim/use-memo-map-pull/25), [#27](https://github.com/compulim/use-memo-map-pull/27), and [#29](https://github.com/compulim/use-memo-map/pull/29)
   - Production dependencies
   - Development dependencies

## Specific changes

> Please list each individual specific change in this pull request.

- Run `npm version --no-git-tag-version preminor`
- Update `/packages/use-memo-map/package.json/peerDependencies/react` to `>=16.8.0`
- Add `switch:react:*` for testing against various version of React